### PR TITLE
Update Tabbar.swift

### DIFF
--- a/MovieSwift/MovieSwift/views/components/tabs/Tabbar.swift
+++ b/MovieSwift/MovieSwift/views/components/tabs/Tabbar.swift
@@ -18,9 +18,9 @@ struct Tabbar : View {
 
     var body: some View {
         TabbedView(selection: $selectedTab) {
-            MoviesHome().tabItemLabel(Text("Movies")).tag(Tab.movies)
-            DiscoverView().tabItemLabel(Text("Discover")).tag(Tab.discover)
-            MyLists().tabItemLabel(Text("My Lists")).tag(Tab.myLists)
+            MoviesHome().tabItemLabel(VStack{Image("tab_movie");Text("Movies")}).tag(Tab.movies)
+            DiscoverView().tabItemLabel(VStack{Image("tab_discover");Text("Discover")}).tag(Tab.discover)
+            MyLists().tabItemLabel(Image("tab_my_list");Text("My Lists")}).tag(Tab.myLists)
         }
             .edgesIgnoringSafeArea(.top)
     }


### PR DESCRIPTION
Love this, but you need some images on those tabs! SF Symbols (eg., Image(systemName: "circle")) images don't seem to work, so you'll need to add PNG/PDFs as Assets to display tab bar images. Thanks!