### PR TITLE
Update NotificationBadge.swift

### DIFF
--- a/MovieSwift/MovieSwift/views/shared/badges/NotificationBadge.swift
+++ b/MovieSwift/MovieSwift/views/shared/badges/NotificationBadge.swift
@@ -8,25 +8,35 @@
 
 import SwiftUI
 
-struct NotificationBadge : View {
+struct NotificationBadge: View {
     let text: String
     let color: Color
     @Binding var show: Bool
-    
+
     var animation: Animation {
         Animation
             .spring(initialVelocity: 5)
             .speed(2)
+            .delay(0.3)
     }
-    
+
     var body: some View {
-        Text(text)
+        if show {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                /// Calling a global `store` which should be refactored to local
+                /// using `@EnvironmentObject var store: AppState` etc.
+                store.dispatch(action: TaskActions.Notification(show: false, message: ""))
+            }
+        }
+
+        return Text(text)
             .color(.white)
             .padding()
             .background(color)
             .cornerRadius(8)
-            .scaleEffect(show ? 1: 0.5)
+            .scaleEffect(show ? 1 : 0.5)
             .opacity(show ? 1 : 0)
             .animation(animation)
     }
 }
+


### PR DESCRIPTION
Really love this! I updated NotificationBadge view to disappear, using a call to `store.dispatch()` where I hold global state for notifications. This way I can eventually create a notification management queue, showing multiple notifications, etc.

Also it wasn't easy to find the proper place to call `DispatchQueue()` but the View lifecycle is called upon every update to the View state so using a `var body : some View { command; return {} }` pattern was the best way to manage this. 

Thanks!