### PR TITLE
Fixes typo in `.topRated` case in APIService

### DIFF
--- a/MovieSwift/MovieSwift/services/APIService.swift
+++ b/MovieSwift/MovieSwift/services/APIService.swift
@@ -21,7 +21,7 @@ struct APIService {
     }
     
     enum Endpoint {
-        case popular, toRated, upcoming, nowPlaying, trending
+        case popular, topRated, upcoming, nowPlaying, trending
         case movieDetail(movie: Int), recommended(movie: Int), similar(movie: Int)
         case credits(movie: Int), review(movie: Int)
         case searchMovie, searchKeyword, searchPerson
@@ -38,7 +38,7 @@ struct APIService {
                 return "movie/popular"
             case .popularPersons:
                 return "person/popular"
-            case .toRated:
+            case .topRated:
                 return "movie/top_rated"
             case .upcoming:
                 return "movie/upcoming"

--- a/MovieSwift/MovieSwift/views/components/moviesHome/models/MoviesMenu.swift
+++ b/MovieSwift/MovieSwift/views/components/moviesHome/models/MoviesMenu.swift
@@ -25,7 +25,7 @@ enum MoviesMenu: Int, CaseIterable {
     func endpoint() -> APIService.Endpoint {
         switch self {
         case .popular: return APIService.Endpoint.popular
-        case .topRated: return APIService.Endpoint.toRated
+        case .topRated: return APIService.Endpoint.topRated
         case .upcoming: return APIService.Endpoint.upcoming
         case .nowPlaying: return APIService.Endpoint.nowPlaying
         case .trending: return APIService.Endpoint.trending


### PR DESCRIPTION
I was perusing the code and noticed that this was probably intended to be `.topRated`.