### PR TITLE
Remove store variable for better performance

### DIFF
--- a/MovieSwift/MovieSwift/views/components/moviesHome/MoviesHome.swift
+++ b/MovieSwift/MovieSwift/views/components/moviesHome/MoviesHome.swift
@@ -22,7 +22,6 @@ struct MoviesHome : View {
         }
     }
 
-    @EnvironmentObject private var store: Store<AppState>
     @ObservedObject private var selectedMenu = MoviesSelectedMenuStore(selectedMenu: MoviesMenu.allCases.first!)
     @State private var isSettingPresented = false
     @State private var homeMode = HomeMode.list


### PR DESCRIPTION
As long as a view has a reference to global `store`. Any update on store from other places will force to refresh the view.  

On the other hand, in order to dispatch an action, we have to use global `store` within a view. So i think it's a drawback of this structure.