### PR TITLE
Use a Set to remove duplicate IDs in people lists

### DIFF
--- a/MovieSwift/Shared/flux/reducers/PeopleReducer.swift
+++ b/MovieSwift/Shared/flux/reducers/PeopleReducer.swift
@@ -15,8 +15,8 @@ func peoplesStateReducer(state: PeoplesState, action: Action) -> PeoplesState {
     case let action as PeopleActions.SetMovieCasts:
         state = mergePeople(peoples: action.response.cast, state: state)
         state = mergePeople(peoples: action.response.crew, state: state)
-        state.peoplesMovies[action.movie] = action.response.cast.map{ $0.id } + action.response.crew.map{ $0.id }
-        
+        state.peoplesMovies[action.movie] = Set(action.response.cast.map{ $0.id } + action.response.crew.map{ $0.id })
+
     case let action as PeopleActions.SetSearch:
         if action.page == 1 {
             state.search[action.query] = action.response.results.map{ $0.id }

--- a/MovieSwift/Shared/flux/state/PeoplesState.swift
+++ b/MovieSwift/Shared/flux/state/PeoplesState.swift
@@ -11,7 +11,7 @@ import SwiftUIFlux
 
 struct PeoplesState: FluxState, Codable {
     var peoples: [Int: People] = [:]
-    var peoplesMovies: [Int: [Int]] = [:]
+    var peoplesMovies: [Int: Set<Int>] = [:]
     var search: [String: [Int]] = [:]
     var popular: [Int] = []
     


### PR DESCRIPTION
**Problem**: App crashes when a movie detail for Tenet (and many more movies) is presented.
**Cause**: Cast & Crew Views use a LazyGrid with ID’s, but some people in crew occur multiple times with different job/department but same same id. The ID duplicates cause a SwiftUI assertion failure which cause an app crash.
**Solution**: Use a `Set` collection type to eliminate duplicate ID’s (fixes #54).

**Comment**: The current AppState struct is not made to store multiple occurences of the same people with a different job in the same movie. And hence the data coming from the movie db is partially lost when it parsed and merged into the app state.